### PR TITLE
Tag node with puppet environment that was applied

### DIFF
--- a/lib/puppet/reports/datadog_reports.rb
+++ b/lib/puppet/reports/datadog_reports.rb
@@ -151,6 +151,10 @@ Puppet::Reports.register_report(:datadog_reports) do
       }
     end
 
+    environment_tag = "puppet.environment:#{@msg_environment}"
+    Puppet.debug "Tagging #{@msg_host} with '#{@environment_tag}'"
+    @dog.add_tags(@msg_host, [environment_tag])
+
     Puppet.debug "Sending events for #{@msg_host} to Datadog"
     @dog.emit_event(Dogapi::Event.new(event_data,
                                       :msg_title => event_title,


### PR DESCRIPTION
When reporting Puppet run completion to DataDog, also tag the host with the Puppet environment that was applied.

Right now, all we get in DataDog monitors is that the host was not on some list of environments. This will allow it to report the environment it is actually on without having to go find that somewhere else.
