### PR TITLE
allow not managing the datadog repo

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -442,6 +442,7 @@ class datadog_agent(
         }
       } else {
         class { 'datadog_agent::ubuntu::agent6':
+          manage_repo           => $manage_repo,
           agent_version         => $agent_version,
           service_ensure        => $service_ensure,
           service_enable        => $service_enable,

--- a/manifests/reports.pp
+++ b/manifests/reports.pp
@@ -17,9 +17,9 @@ class datadog_agent::reports(
   $api_key,
   $puppetmaster_user,
   $dogapi_version,
+  $check_environments,
   $hostname_extraction_regex = undef,
   $datadog_site = 'datadoghq.com',
-  $check_environments,
 ) {
 
   include datadog_agent

--- a/manifests/ubuntu/agent6.pp
+++ b/manifests/ubuntu/agent6.pp
@@ -35,6 +35,7 @@ class datadog_agent::ubuntu::agent6(
   }
 
   if $manage_repo {
+    $dd_package_requires = [Apt::Source['datadog6'], Class['apt::update']]
     apt::source { 'datadog6':
       comment  => 'Datadog Agent 6 Repository',
       location => $location,
@@ -43,6 +44,8 @@ class datadog_agent::ubuntu::agent6(
       key      => $key,
       require  => Exec['apt-transport-https'],
     }
+  } else {
+    $dd_package_requires = []
   }
 
   package { 'datadog-agent-base':
@@ -52,8 +55,7 @@ class datadog_agent::ubuntu::agent6(
 
   package { $datadog_agent::params::package_name:
     ensure  => $agent_version,
-    require => [Apt::Source['datadog6'],
-                Class['apt::update']],
+    require => $dd_package_requires,
   }
 
   if $service_provider {

--- a/manifests/ubuntu/agent6.pp
+++ b/manifests/ubuntu/agent6.pp
@@ -30,11 +30,11 @@ class datadog_agent::ubuntu::agent6(
     $key = {}
   }
 
-  apt::source { 'datadog':
-    ensure => absent,
-  }
-
   if $manage_repo {
+    apt::source { 'datadog':
+      ensure => absent,
+    }
+
     $dd_package_requires = [Apt::Source['datadog6'], Class['apt::update']]
     apt::source { 'datadog6':
       comment  => 'Datadog Agent 6 Repository',

--- a/manifests/ubuntu/agent6.pp
+++ b/manifests/ubuntu/agent6.pp
@@ -9,6 +9,7 @@ class datadog_agent::ubuntu::agent6(
   String $location = $datadog_agent::params::agent6_default_repo,
   String $release = $datadog_agent::params::apt_default_release,
   String $repos = '6',
+  Boolean $manage_repo = true,
   Boolean $skip_apt_key_trusting = false,
   String $service_ensure = 'running',
   Boolean $service_enable = true,
@@ -33,13 +34,15 @@ class datadog_agent::ubuntu::agent6(
     ensure => absent,
   }
 
-  apt::source { 'datadog6':
-    comment  => 'Datadog Agent 6 Repository',
-    location => $location,
-    release  => $release,
-    repos    => $repos,
-    key      => $key,
-    require  => Exec['apt-transport-https'],
+  if $manage_repo {
+    apt::source { 'datadog6':
+      comment  => 'Datadog Agent 6 Repository',
+      location => $location,
+      release  => $release,
+      repos    => $repos,
+      key      => $key,
+      require  => Exec['apt-transport-https'],
+    }
   }
 
   package { 'datadog-agent-base':


### PR DESCRIPTION
Upstream wants the datadog apt repo to be `present` or `absent`, but our setup creates a dependency loop either way. So this change passes the `false` that is allowed at the top level to the apt manifest, instead of just to the yum one.