### PR TITLE
W-7827284 fix from upstream, stop managing apt-transport-https

### DIFF
--- a/manifests/ubuntu/agent6.pp
+++ b/manifests/ubuntu/agent6.pp
@@ -17,10 +17,6 @@ class datadog_agent::ubuntu::agent6(
   Optional[String] $apt_keyserver = undef,
 ) inherits datadog_agent::params {
 
-  exec { 'apt-transport-https':
-    command => '/usr/bin/apt-get install -y -q apt-transport-https'
-  }
-
   if !$skip_apt_key_trusting {
     $key = {
       'id' => $apt_key,
@@ -42,7 +38,6 @@ class datadog_agent::ubuntu::agent6(
       release  => $release,
       repos    => $repos,
       key      => $key,
-      require  => Exec['apt-transport-https'],
     }
   } else {
     $dd_package_requires = []

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "datadog-datadog_agent",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": "James Turnbull (<james@lovedthanlost.net>) and Rob Terhaar (<rob@atlanticdynamic>) for Datadog Inc.",
   "summary": "Install the Datadog monitoring agent and report Puppet runs to Datadog",
   "license": "Apache-2.0",

--- a/spec/classes/datadog_agent_ubuntu_spec.rb
+++ b/spec/classes/datadog_agent_ubuntu_spec.rb
@@ -101,10 +101,6 @@ describe 'datadog_agent::ubuntu::agent6' do
 
   # it should install the packages
   it do
-    should contain_exec('apt-transport-https')\
-      .that_comes_before('file[/etc/apt/sources.list.d/datadog6.list]')
-  end
-  it do
     should contain_package('datadog-agent-base')\
       .with_ensure('absent')\
       .that_comes_before('package[datadog-agent]')


### PR DESCRIPTION
### What does this PR do?

Cherry picks a change from the upstream: see https://github.com/DataDog/puppet-datadog-agent/pull/504; this removes management of apt-transport-https.

### Motivation

Conflicts with our profile::base class which already manages this package. We want to clean up our puppet-agent runs so they aren't making "corrective changes" each time, so daily triage will pick up future unexpected changes.

### Describe your test plan

Dev instances running on this branch now report no changes:
```
$ ssh kafka-manager-a001-ash-dev sudo puppet agent -t
Notice: Local environment: 'production' doesn't match server specified node environment 'feature_W_7827284_corrective', switching agent to 'feature_W_7827284_corrective'.
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for kafka-manager-a001-ash-dev.krxd.net
Info: Applying configuration version 'puppet-compiler-a009-ash-prod-feature_W_7827284_corrective-8bc9bb4585b'
Notice: Applied catalog in 32.56 seconds

$ ssh richbraun-dev001-ash-dev.krxd.net sudo puppet agent -t
Notice: Local environment: 'production' doesn't match server specified node environment 'feature_W_7827284_corrective', switching agent to 'feature_W_7827284_corrective'.
Info: Retrieving pluginfacts
Info: Retrieving plugin
Info: Retrieving locales
Info: Loading facts
Info: Caching catalog for richbraun-dev001-ash-dev.krxd.net
Info: Applying configuration version 'puppet-compiler-a005-ash-prod-feature_W_7827284_corrective-8bc9bb4585b'
Notice: Applied catalog in 17.16 seconds
```
See also the https://puppet-ui-prod.krxd.net/#/inspect/overview dashboard for node reports.